### PR TITLE
138169: TooltipCache

### DIFF
--- a/pm4j-core/src/main/java/org/pm4j/core/pm/annotation/PmCacheCfg.java
+++ b/pm4j-core/src/main/java/org/pm4j/core/pm/annotation/PmCacheCfg.java
@@ -72,8 +72,7 @@ public @interface PmCacheCfg {
   /**
    * @return <code>true</code> when tooltip's should be cached.
    */
-// XXX olaf: not yet done because it was not in the profiler hit list.
-//  CacheMode tooltip() default CacheMode.UNKNOWN;
+ CacheMode tooltip() default CacheMode.NOT_SPECIFIED;
 
   /**
    * @return The value caching strategy.
@@ -114,6 +113,7 @@ public @interface PmCacheCfg {
   public static final String ATTR_VISIBILITY = "visibility";
   public static final String ATTR_ENABLEMENT = "enablement";
   public static final String ATTR_TITLE = "title";
+  public static final String ATTR_TOOLTIP = "tooltip";
   public static final String ATTR_VALUE = "value";
   public static final String ATTR_OPTIONS = "options";
   public static final String ATTR_NODES = "nodes";

--- a/pm4j-core/src/main/java/org/pm4j/core/pm/api/PmCacheApi.java
+++ b/pm4j-core/src/main/java/org/pm4j/core/pm/api/PmCacheApi.java
@@ -23,6 +23,7 @@ public class PmCacheApi {
     VISIBILITY,
     ENABLEMENT,
     TITLE,
+    TOOLTIP,
     VALUE,
     OPTIONS,
     NODES,
@@ -33,6 +34,7 @@ public class PmCacheApi {
             CacheKind.VISIBILITY,
             CacheKind.ENABLEMENT,
             CacheKind.TITLE,
+            CacheKind.TOOLTIP,
             CacheKind.VALUE,
             CacheKind.OPTIONS,
             CacheKind.NODES)));

--- a/pm4j-core/src/main/java/org/pm4j/core/pm/impl/InternalCacheStrategyFactory.java
+++ b/pm4j-core/src/main/java/org/pm4j/core/pm/impl/InternalCacheStrategyFactory.java
@@ -47,6 +47,8 @@ class InternalCacheStrategyFactory {
         return new CacheStrategyForEnablement(cache.clear());
       case TITLE:
         return new CacheStrategyForTitle(cache.clear());
+      case TOOLTIP:
+        return new CacheStrategyForTooltip(cache.clear());
       case VISIBILITY:
         return new CacheStrategyForVisibility(cache.clear());
       case NODES:
@@ -85,6 +87,21 @@ class InternalCacheStrategyFactory {
     }
     @Override protected void clearImpl(PmObjectBase pm) {
       pm.pmCachedTitle = null;
+    }
+  };
+
+  private static class CacheStrategyForTooltip extends CacheStrategyBase<PmObjectBase> {
+    private CacheStrategyForTooltip(Clear cacheClear) {
+      super("CACHE_TOOLTIP_LOCAL", cacheClear);
+    }
+    @Override protected Object readRawValue(PmObjectBase pm) {
+      return pm.pmCachedTooltip;
+    }
+    @Override protected void writeRawValue(PmObjectBase pm, Object value) {
+      pm.pmCachedTooltip = (String)value;
+    }
+    @Override protected void clearImpl(PmObjectBase pm) {
+      pm.pmCachedTooltip = null;
     }
   };
 

--- a/pm4j-core/src/main/java/org/pm4j/core/pm/impl/InternalPmCacheCfgUtil.java
+++ b/pm4j-core/src/main/java/org/pm4j/core/pm/impl/InternalPmCacheCfgUtil.java
@@ -263,6 +263,19 @@ class DeprInternalPmCacheCfgUtil {
     }
   };
 
+  // what is this for? seems mot to be used
+  private static final CacheStrategy CACHE_TOOLTIP_LOCAL = new CacheStrategyBase<PmObjectBase>("CACHE_TOOLTIP_LOCAL") {
+    @Override protected Object readRawValue(PmObjectBase pm) {
+      return pm.pmCachedTooltip;
+    }
+    @Override protected void writeRawValue(PmObjectBase pm, Object value) {
+      pm.pmCachedTooltip = (String)value;
+    }
+    @Override protected void clearImpl(PmObjectBase pm) {
+      pm.pmCachedTooltip = null;
+    }
+  };
+
   private static final CacheStrategy CACHE_VISIBLE_LOCAL = new CacheStrategyBase<PmObjectBase>("CACHE_VISIBLE_LOCAL") {
     @Override protected Object readRawValue(PmObjectBase pm) {
       return pm.pmVisibleCache;
@@ -326,6 +339,13 @@ class DeprInternalPmCacheCfgUtil {
       CacheMode.REQUEST,  new CacheStrategyRequest("CACHE_TITLE_IN_REQUEST", "ti")
     );
 
+  private static final Map<CacheMode, CacheStrategy> CACHE_STRATEGIES_FOR_TOOLTIP =
+      MapUtil.makeFixHashMap(
+        CacheMode.OFF,      CacheStrategyNoCache.INSTANCE,
+        CacheMode.ON,       CACHE_TOOLTIP_LOCAL,
+        CacheMode.REQUEST,  new CacheStrategyRequest("CACHE_TOOLTIP_IN_REQUEST", "tt")
+      );
+
   private static final Map<CacheMode, CacheStrategy> CACHE_STRATEGIES_FOR_ENABLEMENT =
     MapUtil.makeFixHashMap(
       CacheMode.OFF,      CacheStrategyNoCache.INSTANCE,
@@ -366,6 +386,7 @@ class DeprInternalPmCacheCfgUtil {
       CacheKind.ENABLEMENT, CACHE_STRATEGIES_FOR_ENABLEMENT,
       CacheKind.OPTIONS,    CACHE_STRATEGIES_FOR_OPTIONS,
       CacheKind.TITLE,      CACHE_STRATEGIES_FOR_TITLE,
+      CacheKind.TOOLTIP,    CACHE_STRATEGIES_FOR_TOOLTIP,
       CacheKind.VALUE,      CACHE_STRATEGIES_FOR_ATTR_VALUE,
       CacheKind.VISIBILITY, CACHE_STRATEGIES_FOR_VISIBILITY,
       CacheKind.NODES,CACHE_STRATEGIES_FOR_NODES
@@ -376,6 +397,7 @@ class DeprInternalPmCacheCfgUtil {
       CacheKind.ENABLEMENT, PmCacheCfg.ATTR_ENABLEMENT,
       CacheKind.OPTIONS,    PmCacheCfg.ATTR_OPTIONS,
       CacheKind.TITLE,      PmCacheCfg.ATTR_TITLE,
+      CacheKind.TOOLTIP,    PmCacheCfg.ATTR_TOOLTIP,
       CacheKind.VALUE,      PmCacheCfg.ATTR_VALUE,
       CacheKind.VISIBILITY, PmCacheCfg.ATTR_VISIBILITY,
       CacheKind.NODES,      PmCacheCfg.ATTR_NODES

--- a/pm4j-core/src/test/java/org/pm4j/core/pm/PmAttrCacheTest2.java
+++ b/pm4j-core/src/test/java/org/pm4j/core/pm/PmAttrCacheTest2.java
@@ -179,6 +179,36 @@ public class PmAttrCacheTest2 {
     }
   }
 
+  @Test
+  public void testTitleCache() {
+    MyPojo p = new MyPojo();
+    MyPojoPm pPm = new MyPojoPm(new PmConversationImpl(), p);
+
+    p.s = "abc";
+    assertEquals("abc Title", pPm.sCachedTitleAndTooltip.getPmTitle());
+
+    p.s = "123";
+    assertEquals("abc Title", pPm.sCachedTitleAndTooltip.getPmTitle());
+
+    PmCacheApi.clearPmCache(pPm);
+    assertEquals("123 Title", pPm.sCachedTitleAndTooltip.getPmTitle());
+  }
+
+  @Test
+  public void testTooltipCache() {
+    MyPojo p = new MyPojo();
+    MyPojoPm pPm = new MyPojoPm(new PmConversationImpl(), p);
+
+    p.s = "abc";
+    assertEquals("abc Tooltip", pPm.sCachedTitleAndTooltip.getPmTooltip());
+
+    p.s = "123";
+    assertEquals("abc Tooltip", pPm.sCachedTitleAndTooltip.getPmTooltip());
+
+    PmCacheApi.clearPmCache(pPm);
+    assertEquals("123 Tooltip", pPm.sCachedTitleAndTooltip.getPmTooltip());
+  }
+
   // -- Domain model --
 
   public static class MyPojo {
@@ -203,6 +233,20 @@ public class PmAttrCacheTest2 {
     public final PmAttrString s2 = new PmAttrStringImpl(this);
 
     public final MyTab tab = new MyTab(this);
+
+    @PmCacheCfg2(@Cache(property={CacheKind.TOOLTIP, CacheKind.TITLE}))
+    @PmAttrCfg(valuePath="pmBean.s")
+    public final PmAttrString sCachedTitleAndTooltip = new PmAttrStringImpl(this) {
+      @Override
+      protected String getPmTitleImpl() {
+        return getValueAsString() + " Title";
+      };
+
+      @Override
+      protected String getPmTooltipImpl() {
+        return getValueAsString() + " Tooltip";
+      };
+    };
 
     @PmCacheCfg2(@Cache(property=CacheKind.ALL))
     @PmAttrCfg(valuePath="pmBean.s")


### PR DESCRIPTION
- added Tooltip cache with test
- had to add it to the deprecated PmCacheCfg and all utils as well
	otherwise mapping old<-> new can't work
	and NuppPointerExceptions are thrown on map access
- so far kept the addErrorMessagesToTooltip feature,
	by just adding the error message to cached tooltip